### PR TITLE
chore: allow context within shopifyDetails

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -340,7 +340,6 @@ analytics.subscribe("product_viewed", (event) => {
         contextualFieldMapping,
     );
     const shopifyDetailsObject = event;
-    delete shopifyDetailsObject.context;
 
     contextualPayload.shopifyDetails = shopifyDetailsObject;
 
@@ -379,7 +378,6 @@ analytics.subscribe("cart_viewed", (event) => {
         contextualFieldMapping,
     );
     const shopifyDetailsObject = event;
-    delete shopifyDetailsObject.context;
     contextualPayload.shopifyDetails = shopifyDetailsObject;
 
     rudderanalytics.track("Cart Viewed", trackProperties, {
@@ -403,7 +401,6 @@ analytics.subscribe("product_added_to_cart", (event) => {
         contextualFieldMapping,
     );
     const shopifyDetailsObject = event;
-    delete shopifyDetailsObject.context;
     contextualPayload.shopifyDetails = shopifyDetailsObject;
 
     rudderanalytics.track("Product Added", trackProperties, {
@@ -429,7 +426,6 @@ analytics.subscribe("product_removed_from_cart", (event) => {
         contextualFieldMapping,
     );
     const shopifyDetailsObject = event;
-    delete shopifyDetailsObject.context;
     contextualPayload.shopifyDetails = shopifyDetailsObject;
 
     rudderanalytics.track("Product Removed", trackProperties, {
@@ -467,7 +463,6 @@ analytics.subscribe("collection_viewed", (event) => {
         contextualFieldMapping,
     );
     const shopifyDetailsObject = event;
-    delete shopifyDetailsObject.context;
     contextualPayload.shopifyDetails = shopifyDetailsObject;
 
     rudderanalytics.track(
@@ -514,7 +509,6 @@ analytics.subscribe("checkout_started", (event) => {
         contextualFieldMapping,
     );
     const shopifyDetailsObject = event;
-    delete shopifyDetailsObject.context;
     contextualPayload.shopifyDetails = shopifyDetailsObject;
 
     rudderanalytics.track("Checkout Started", finalProperties, {
@@ -538,7 +532,6 @@ analytics.subscribe("search_submitted", (event) => {
         contextualFieldMapping,
     );
     const shopifyDetailsObject = event;
-    delete shopifyDetailsObject.context;
     contextualPayload.shopifyDetails = shopifyDetailsObject;
 
     rudderanalytics.track("Products Searched", payload, {
@@ -580,7 +573,6 @@ analytics.subscribe("checkout_completed", (event) => {
         contextualFieldMapping,
     );
     const shopifyDetailsObject = event;
-    delete shopifyDetailsObject.context;
     contextualPayload.shopifyDetails = shopifyDetailsObject;
 
     rudderanalytics.track("Order Completed", trackProperties, {
@@ -600,7 +592,6 @@ analytics.subscribe("page_viewed", (event) => {
         contextualFieldMapping,
     );
     const shopifyDetailsObject = event;
-    delete shopifyDetailsObject.context;
     contextualPayload.shopifyDetails = shopifyDetailsObject;
 
     const pageProperties = {
@@ -644,7 +635,6 @@ analytics.subscribe("checkout_address_info_submitted", (event) => {
         contextualFieldMapping,
     );
     const shopifyDetailsObject = event;
-    delete shopifyDetailsObject.context;
     contextualPayload.shopifyDetails = shopifyDetailsObject;
     const trackProperties = {
         checkout_id: data.checkout.token,
@@ -690,7 +680,6 @@ analytics.subscribe("checkout_contact_info_submitted", (event) => {
         contextualFieldMapping,
     );
     const shopifyDetailsObject = event;
-    delete shopifyDetailsObject.context;
     contextualPayload.shopifyDetails = shopifyDetailsObject;
     const trackProperties = {
         checkout_id: data.checkout.token,
@@ -736,7 +725,6 @@ analytics.subscribe("checkout_shipping_info_submitted", (event) => {
         contextualFieldMapping,
     );
     const shopifyDetailsObject = event;
-    delete shopifyDetailsObject.context;
     contextualPayload.shopifyDetails = shopifyDetailsObject;
     const trackProperties = {
         checkout_id: data.checkout.token,
@@ -782,7 +770,6 @@ analytics.subscribe("payment_info_submitted", (event) => {
         contextualFieldMapping,
     );
     const shopifyDetailsObject = event;
-    delete shopifyDetailsObject.context;
     contextualPayload.shopifyDetails = shopifyDetailsObject;
     const trackProperties = {
         checkout_id: data.checkout.token,


### PR DESCRIPTION
**Fixes** # (*issue*)

context object from shopify raw payload should go as context.shopifyDetails.context --> It's just raw shopify payload request going under context.shopifyDetails

Resolves INT-3399

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
